### PR TITLE
선언부와 구현부 매크로를 분리하였습니다.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,11 +42,14 @@ C의 매크로 함수를 응용하여 C++의 STL(Standard Template Library)을 �
 
 ## 사용례
   
-C++의 std::array에 해당하는 매크로는 decl_array입니다.  
+C++의 std::array에 해당하는 매크로는 decl_array, def_array 입니다.  
 아래와 같이 선언하면 int 타입에 길이가 10인 배열 타입이 IntArray라는 이름으로 구체화됩니다.  
 ```
 decl_array(IntArray, int, 10)
+def_array(IntArray, int, 10)
 ```
+decl_XXX 는 .h파일에 들어갈 전방선언이 포함되어있습니다.
+def_XXX 는 .c파일에 들어갈 메서드 구현이 포함되어있습니다. def_XXX를 .h 파일에서 사용하시면 안됩니다.
   
   
 그리고 객체의 생성은 아래와 같이 합니다. 꼭 new를 사용해야 하는 건 아니지만, 추천하지 않습니다.  

--- a/include/array.h
+++ b/include/array.h
@@ -5,7 +5,7 @@
 #include <stdbool.h>
 
 //매크로로 확장되는, 배열 유사템플릿입니다.
-//정적배열의 래퍼 유사클래스를 생성합니다.
+//정적배열의 래퍼 유사클래스 선언을 생성합니다.
 #define decl_array(declname, type, length)                                                                                  \
                                                                                                                             \
     /*배열 유사클래스 전방선언*/                                                                                 \
@@ -125,8 +125,10 @@
     void declname##_for_each_ptr(declname *, void (*)(type *));                                                             \
     void declname##_for_each_cptr(const declname *, void (*)(const type *));                                                \
     /*비멤버 함수*/                                                                                                    \
-    declname new_##declname(void);                                                                                          \
-                                                                                                                            \
+    declname new_##declname(void);
+
+//정적배열의 래퍼 유사클래스 구현을 생성합니다.
+#define def_array(declname, type, length)                                                                                  \
     /*배열 메서드 정의.*/                                                                                            \
     size_t declname##_size(const declname *self)                                                                            \
     {                                                                                                                       \

--- a/include/circular_list.h
+++ b/include/circular_list.h
@@ -6,7 +6,7 @@
 #include <assert.h>
 
 //매크로로 확장되는, 연결리스트 유사템플릿입니다.
-//연결리스트의 유사클래스를 생성합니다.
+//연결리스트의 유사클래스 선언을 생성합니다.
 #define decl_circular_list(declname, type)                                                                         \
                                                                                                                    \
   /*리스트 유사클래스 전방선언이오*/                                                                 \
@@ -53,16 +53,6 @@
     type value;            /*값입니다..*/                                                                      \
     declname##_node *next; /*다음 포인터입니다.*/                                                          \
   };                                                                                                               \
-                                                                                                                   \
-  declname##_node *declname##_new_node(declname##_node *prev, const type *v, declname##_node *next)                \
-  {                                                                                                                \
-    declname##_node *temp =                                                                                        \
-        malloc(sizeof(declname##_node));                                                                           \
-    temp->prev = prev;                                                                                             \
-    temp->value = *v;                                                                                              \
-    temp->next = next;                                                                                             \
-    return temp;                                                                                                   \
-  }                                                                                                                \
                                                                                                                    \
   /*실체화되는 연결리스트 유사클래스요*/                                                           \
   struct declname                                                                                                  \
@@ -150,9 +140,23 @@
   void declname##_for_each_ptr(declname *, void (*)(type *));                                                      \
   void declname##_for_each_cptr(const declname *, void (*)(const type *));                                         \
   /*비멤버 함수요*/                                                                                          \
-  declname new_##declname(void);                                                                                   \
+  declname new_##declname(void);
+
+//연결리스트의 유사클래스 구현을 생성합니다.
+#define def_circular_list(declname, type)                                                                         \
                                                                                                                    \
   /*이것이 바로... [정의]란 것이다...*/                                                                 \
+                                                                                                                   \
+  declname##_node *declname##_new_node(declname##_node *prev, const type *v, declname##_node *next)                \
+  {                                                                                                                \
+    declname##_node *temp =                                                                                        \
+        malloc(sizeof(declname##_node));                                                                           \
+    temp->prev = prev;                                                                                             \
+    temp->value = *v;                                                                                              \
+    temp->next = next;                                                                                             \
+    return temp;                                                                                                   \
+  }                                                                                                                \
+                                                                                                                   \
   void declname##_clear(declname *self)                                                                            \
   {                                                                                                                \
     assert(self != NULL);                                                                                          \

--- a/include/darray.h
+++ b/include/darray.h
@@ -5,7 +5,7 @@
 #include <stdbool.h>
 
 //매크로로 확장되는, 배열 유사템플릿입니다.
-//정적배열의 래퍼 유사클래스를 생성합니다.
+//정적배열의 래퍼 유사클래스 선언을 생성합니다.
 #define decl_darray(declname, type)                                                                                         \
                                                                                                                             \
     /*배열 유사클래스 전방선언*/                                                                                 \
@@ -138,7 +138,10 @@
                                                                                                                             \
     /*비멤버 함수*/                                                                                                    \
     declname new_##declname();                                                                                              \
-    declname new_##declname##_with(size_t);                                                                                 \
+    declname new_##declname##_with(size_t);
+
+//정적배열의 래퍼 유사클래스 구현을 생성합니다.
+#define def_darray(declname, type)                                                                                          \
                                                                                                                             \
     /*배열 메서드 정의.*/                                                                                            \
     void declname##_clear(declname *self)                                                                                   \

--- a/include/forward_list.h
+++ b/include/forward_list.h
@@ -6,7 +6,7 @@
 #include <assert.h>
 
 //매크로로 확장되는, 단방향 연결리스트 유사템플릿입니다.
-//단방향 연결리스트의 유사클래스를 생성합니다.
+//단방향 연결리스트의 유사클래스 선언을 생성합니다.
 #define decl_forward_list(declname, type)                                                                            \
                                                                                                                      \
     /*단방향 리스트 유사클래스 전방선언이오*/                                                       \
@@ -49,14 +49,6 @@
         type value;            /*값입니다..*/                                                                    \
         declname##_node *next; /*다음 포인터입니다.*/                                                        \
     };                                                                                                               \
-                                                                                                                     \
-    declname##_node *declname##_new_node(const type *v, declname##_node *next)                                       \
-    {                                                                                                                \
-        declname##_node *temp = malloc(sizeof(declname##_node));                                                     \
-        temp->value = *v;                                                                                            \
-        temp->next = next;                                                                                           \
-        return temp;                                                                                                 \
-    }                                                                                                                \
                                                                                                                      \
     /*실체화되는 연결리스트 유사클래스요*/                                                           \
     struct declname                                                                                                  \
@@ -132,9 +124,21 @@
     void declname##_for_each_ptr(declname *, void (*)(type *));                                                      \
     void declname##_for_each_cptr(const declname *, void (*)(const type *));                                         \
     /*비멤버 함수요*/                                                                                          \
-    declname new_##declname(void);                                                                                   \
+    declname new_##declname(void);
+
+//단방향 연결리스트의 유사클래스 구현을 생성합니다.
+#define def_forward_list(declname, type)                                                                             \
                                                                                                                      \
     /*이것이 바로... [정의]란 것이다...*/                                                                 \
+                                                                                                                     \
+    declname##_node *declname##_new_node(const type *v, declname##_node *next)                                       \
+    {                                                                                                                \
+        declname##_node *temp = malloc(sizeof(declname##_node));                                                     \
+        temp->value = *v;                                                                                            \
+        temp->next = next;                                                                                           \
+        return temp;                                                                                                 \
+    }                                                                                                                \
+                                                                                                                     \
     void declname##_clear(declname *self)                                                                            \
     {                                                                                                                \
         assert(self != NULL);                                                                                        \

--- a/include/list.h
+++ b/include/list.h
@@ -6,7 +6,7 @@
 #include <assert.h>
 
 //매크로로 확장되는, 연결리스트 유사템플릿입니다.
-//연결리스트의 유사클래스를 생성합니다.
+//연결리스트 유사클래스 선언을 생성합니다.
 #define decl_list(declname, type)                                                                                    \
                                                                                                                      \
     /*리스트 유사클래스 전방선언이오*/                                                                 \
@@ -54,16 +54,6 @@
         \ 
         declname##_node *next; /*다음 포인터입니다.*/                                                        \
     };                                                                                                               \
-                                                                                                                     \
-    declname##_node *declname##_new_node(declname##_node *prev, const type *v, declname##_node *next)                \
-    {                                                                                                                \
-        declname##_node *temp =                                                                                      \
-            malloc(sizeof(declname##_node));                                                                         \
-        temp->prev = prev;                                                                                           \
-        temp->value = *v;                                                                                            \
-        temp->next = next;                                                                                           \
-        return temp;                                                                                                 \
-    }                                                                                                                \
                                                                                                                      \
     /*실체화되는 연결리스트 유사클래스요*/                                                           \
     struct declname                                                                                                  \
@@ -152,7 +142,21 @@
     void declname##_for_each_ptr(declname *, void (*)(type *));                                                      \
     void declname##_for_each_cptr(const declname *, void (*)(const type *));                                         \
     /*비멤버 함수*/                                                                                             \
-    declname new_##declname(void);                                                                                   \
+    declname new_##declname(void);
+
+//연결리스트 유사클래스 구현을 생성합니다.
+#define def_list(declname, type)                                                                                     \
+                                                                                                                     \
+    /*노드 생성자*/                                                                                           \
+    declname##_node *declname##_new_node(declname##_node *prev, const type *v, declname##_node *next)                \
+    {                                                                                                                \
+        declname##_node *temp =                                                                                      \
+            malloc(sizeof(declname##_node));                                                                         \
+        temp->prev = prev;                                                                                           \
+        temp->value = *v;                                                                                            \
+        temp->next = next;                                                                                           \
+        return temp;                                                                                                 \
+    }                                                                                                                \
                                                                                                                      \
     /*메서드 정의부*/                                                                                          \
     void declname##_clear(declname *self)                                                                            \

--- a/include/queue.h
+++ b/include/queue.h
@@ -46,8 +46,9 @@
     const type *declname##_front_cptr(const declname *);                            \
     void declname##_clear(declname *);                                              \
                                                                                     \
-    declname new_##declname(void);                                                  \
-                                                                                    \
+    declname new_##declname(void);
+
+#define def_queue(declname, type)                                                   \
     void declname##_push(declname *self, type value)                                \
     {                                                                               \
         declname##_node *node = (declname##_node *)malloc(sizeof(declname##_node)); \

--- a/include/stack.h
+++ b/include/stack.h
@@ -45,8 +45,9 @@
     size_t declname##_size(const declname *);                                      \
     bool declname##_is_empty(const declname *);                                    \
     bool declname##_is_not_empty(const declname *);                                \
-    void declname##_clear(declname *);                                             \
-                                                                                   \
+    void declname##_clear(declname *);
+
+#define def_stack(declname, type)                                                  \
     void declname##_push(declname *self, type d)                                   \
     {                                                                              \
         declname##_node *ptr = (declname##_node *)malloc(sizeof(declname##_node)); \

--- a/include/vector.h
+++ b/include/vector.h
@@ -8,7 +8,7 @@
 #define VECTOR_ALLOC_DEFAULT 4
 
 //매크로로 확장되는, 동적 가변배열 유사템플릿입니다.
-//정적배열의 래퍼 유사클래스를 생성합니다.
+//동적배열의 래퍼 유사클래스 선언을 생성합니다.
 #define decl_vector(declname, type)                                                                                         \
                                                                                                                             \
     /*배열 유사클래스 전방선언*/                                                                                 \
@@ -153,8 +153,10 @@
     declname new_##declname();                                                                                              \
     declname new_##declname##_with(size_t);                                                                                 \
     void declname##_alloc(declname *);                                                                                      \
-    void declname##_alloc_reduction(declname *);                                                                            \
-                                                                                                                            \
+    void declname##_alloc_reduction(declname *);
+
+//동적배열의 래퍼 유사클래스 구현을 생성합니다.
+#define def_vector(declname, type)                                                                                         \
     /*배열 메서드 정의.*/                                                                                            \
     void declname##_clear(declname *self)                                                                                   \
     {                                                                                                                       \

--- a/test.c
+++ b/test.c
@@ -2,6 +2,7 @@
 #include "include/hashmap.h"
 
 decl_hashmap(Foo, int, int)
+def_hashmap(Foo, int, int)
 
 int main()
 {


### PR DESCRIPTION
main.c가 아닌 파일에서,
헤더에 매크로를 사용하면 링킹에 문제가 생기므로 선언부와 구현부를 분리하였습니다.
선언부의 매크로는 기존과 같으며 구현부의 매크로는 def_XXX 입니다.